### PR TITLE
Excluding current year from analysis.

### DIFF
--- a/mean.pie.r
+++ b/mean.pie.r
@@ -27,7 +27,7 @@ mean.pie<-function(a.ll,m.ll,consts,wys){
 		#This example omputes nitrate+nitrite pie charts for 2014 in the Mississippi River basin by setting the variable "const" to NO3+NO2. For TN and TP you would set the "const" variable to "TN" or "TP".  For a different year you would adjust the "wycur" variable.
 		const<-consts[j]
 		if(p.type[k]=="WY"){aload<-a.ll}else if(p.type[k]=="May"){aload<-m.ll}
-		if(i==1){mlab<-paste(min(wys),max(wys),sep="_")}else if(i==2){mlab<-"1980_1996"}
+		if(i==1){mlab<-paste(min(wys),max(wys)-1,sep="_")}else if(i==2){mlab<-"1980_1996"}
 #Compute the total gulf load and assign it to the variable "gulfpie"
 gulfpie<-mean(aload[aload$SITE_QW_ID=="07373420"&aload$SITE_ABB=="STFR"&aload$WY %in%wys&aload$CONSTIT==const&aload$MODTYPE %in% c("REG","REGHIST"),"TONS"])+mean(aload[aload$SITE_QW_ID=="07381495"&aload$WY %in%wys&aload$CONSTIT==const&aload$MODTYPE %in% c("REG","REGHIST"),"TONS"])
 #Compute the percentage of the total load from the Red River basin and assign it to the variable "redpie"


### PR DESCRIPTION
Casey, I think we need this change so that the app to retains the current functionality in the MRB page.
Please review this page:
http://cida-test.er.usgs.gov/quality/rivers/mississippi
The version of the app and the data on that QA url assumed a current water year of 2013. It looks like the goal of the app is to contrast the period 1993:(current_water_year - 1) on the left with current_water_year on the right. If that is the experience we still want, we should merge this pull request so that the R scripts calculate values for the year range 1993:(current_water_year - 1) instead of 1993:current_water_year.